### PR TITLE
Use correct target and tempdir paths

### DIFF
--- a/BlackVueDownloader.PCL/BlackVueDownloader.cs
+++ b/BlackVueDownloader.PCL/BlackVueDownloader.cs
@@ -96,7 +96,7 @@ namespace BlackVueDownloader.PCL
 
             try
             {
-                filepath = Path.Combine("Record", filename);
+                filepath = Path.Combine(targetdir, filename);
             }
             catch (Exception e)
             {
@@ -107,7 +107,7 @@ namespace BlackVueDownloader.PCL
 
             try
             {
-                temp_filepath = Path.Combine("_tmp", filename);
+                temp_filepath = Path.Combine(tempdir, filename);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Currently files already downloaded get downloaded over and over on each run, although they will print an exception since it already exists.

This is due to a mistake in the path combines not using the absolute paths coming from higher in the application.

I fixed this and ran it against my own cam to verify it now correctly ignores already existing files.